### PR TITLE
Fixes Color Resetting from subdiff

### DIFF
--- a/ccdiff
+++ b/ccdiff
@@ -246,14 +246,28 @@ sub subdiff {
 	    }
 	if (@{$c[0]}) {
 	    $d1 .= $cml.$clr_old;
-	    $d1 .= $_ for @{$c[0]};
+        for (@{$c[0]}) {
+            if ($_ eq "\n") {
+                $d1 .= $reset . $_ . $clr_new;
+                }
+            else {
+                $d1 .= $_;
+                }
+        }
 	    $d1 .= $reset.$cmr;
 	    $x1 .= $_ for map { s/[^\t\r\n]/$cmd/gr } @{$c[0]};
 	    $opt_v and push @h1, map { $opt_U ? charnames::viacode (ord) : unpack "H*"; } @{$c[0]};
 	    }
 	if (@{$c[1]}) {
 	    $d2 .= $cml.$clr_new;
-	    $d2 .= $_ for @{$c[1]};
+        for (@{$c[1]}) {
+            if ($_ eq "\n") {
+                $d2 .= $reset . $_ . $clr_new;
+                }
+            else {
+                $d2 .= $_;
+                }
+        }
 	    $d2 .= $reset.$cmr;
 	    $x2 .= $_ for map { s/[^\t\r\n]/$cma/gr } @{$c[1]};
 	    $opt_v and push @h2, map { $opt_U ? charnames::viacode (ord) : unpack "H*"; } @{$c[1]};


### PR DESCRIPTION
I still considder the behaviour mentioned in https://gist.github.com/ufobat/30a4cd45430a9c566b4ab680f694b0a3 as a bug. I hope my explanation is understandable.

subdiff() used to create a string for a change that
a) starts with a color-sequence
b) contains a multi lined diff chunk
c) ends with the color-reset-sequence.

Later this string is splitted at the newline character and each
chunk was prefixed with $color . '>' . $reset. This $reset interfered
with the color-sequence from a).

This PR adds the color sequeces a) and c) to each single line chunk.