### PR TITLE
README.md: Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ usage: ccdiff [options] file1 [file2]
 # Description
 
 All command-line tools that show the difference between two files fall
-short in showing minor changes visuably useful. This tool tries to give
+short in showing minor changes visually usefully. This tool tries to give
 the look and feel of `diff --color` or `colordiff`, but extending the
 display of colored output from red for deleted lines and green for added
 lines to red for deleted characters and green for added characters within
@@ -150,7 +150,7 @@ There is no provision (yet) for coping with double-width characters.
 Large datasets may consume all available memory, causing the diff to fail.
 
 Not all that can be set from the configuration files can be overruled by
-comman-line options.
+command-line options.
 
 ## LICENSE
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -11,7 +11,7 @@ usage: ccdiff [options] file1 [file2]
 # Description
 
 All command-line tools that show the difference between two files fall
-short in showing minor changes visuably useful. This tool tries to give
+short in showing minor changes visually usefully. This tool tries to give
 the look and feel of `diff --color` or `colordiff`, but extending the
 display of colored output from red for deleted lines and green for added
 lines to red for deleted characters and green for added characters within
@@ -148,7 +148,7 @@ There is no provision (yet) for coping with double-width characters.
 Large datasets may consume all available memory, causing the diff to fail.
 
 Not all that can be set from the configuration files can be overruled by
-comman-line options.
+command-line options.
 
 ## LICENSE
 


### PR DESCRIPTION
"visuably" is not a word; I assume it was a typo for "visually" (or possibly "visibly)". "showing ... useful" isn't grammatical; "showing ... usefully" is, but "visually usefully" still feels convoluted. Instead of "visually usefully", maybe "clearly" would be simpler.