### PR TITLE
Fix typos in documentation

### DIFF
--- a/ccdiff
+++ b/ccdiff
@@ -545,7 +545,7 @@ sub read_rc {
     } # read_rc
 
 # Return the known colors from Term::ANSIColor
-# Stolen striaght from the pm
+# Stolen straight from the pm
 sub tac_colors {
     my %c256;
     foreach my $r (0 .. 5) {
@@ -609,7 +609,7 @@ ccdiff - Colored Character diff
 
 =item --help -?
 
-Show a summary op the available command-line options and exit.
+Show a summary of the available command-line options and exit.
 
 =item --version -V
 
@@ -728,7 +728,7 @@ as C<chr_old> (the character used as marker under removed characters) and
 C<chr_new> (the character used as marker under added characters).
 
 If C<--ellipsis> is also in effect and either the C<chr_eli> is longer than
-one character or C<--verbose> level is over 2, this options is automatically
+one character or C<--verbose> level is over 2, this option is automatically
 disabled.
 
 =item --ascii -a
@@ -809,7 +809,7 @@ Defines the number of lines a change block may differ before the fall-back of
 horizontal diff to vertical diff.
 
 If a chunk describes a change, and the number of lines in the original block
-has less or more lines than the new block and that difference exceeds this
+has fewer or more lines than the new block and that difference exceeds this
 threshold, C<ccdiff> will fall-back to vertical diff.
 
 =item --heuristics=n -h n
@@ -860,12 +860,12 @@ and C<-B>.
 
 =item --ignore-trailing-space -Z
 
-Ignore changes in trailing white-space (TAB's and spaces).
+Ignore changes in trailing white-space (tabs and spaces).
 
 =item --ignore-ws|ignore-space-change -b
 
-Ignore changes in horizontal white-space (TAB's and spaces). This does not
-include white-space changes that splits non-white-space or removes white-space
+Ignore changes in horizontal white-space (tabs and spaces). This does not
+include white-space changes that split non-white-space or remove white-space
 between two non-white-space elements.
 
 =item --ignore-tab-expansion -E
@@ -891,10 +891,10 @@ in this order:
 and evaluated in that order. Any options specified in a file later in that
 chain will overwrite previously set options.
 
-Option files are only read and evaluated if it is not empty and not writable
+Option files are only read and evaluated if they are not empty and not writable
 by others than the owner.
 
-The syntax of the file is one option per line. where leading and trailing
+The syntax of the file is one option per line, where leading and trailing
 white-space is ignored. If that line then starts with one of the options
 listed below, followed by optional white-space followed by either an C<=> or
 a C<:>, followed by optional white-space and the values, the value is assigned
@@ -941,7 +941,7 @@ default background color.
 
 =item swap (-s)
 
- reverse : false
+ swap    : false
 
 Swap the colors for new and old.
 
@@ -968,7 +968,7 @@ This option may also be specified as
 
  old     : red
 
-Defines the color to be used for delete text. The default is C<red>.
+Defines the color to be used for deleted text. The default is C<red>.
 
 The color C<none> is also accepted and disables this color.
 
@@ -1015,7 +1015,7 @@ This option may also be specified as
 Defines if a header is displayed above the diff (default is 1), supported
 colors are allowed.
 
-If the values is a valid supported color, it will show the header in that
+If the value is a valid supported color, it will show the header in that
 color scheme.  To disable the header set it to C<0> in the RC file or use
 C<--no-header> as a command line argument.
 
@@ -1069,8 +1069,8 @@ with this option, it would be
  [002] 19,19d18
  [005] 42a42,42
 
-When this option contains a positive integer, C<ccdiff> will only show diff
-the diff chunk with that index.
+When this option contains a positive integer, C<ccdiff> will only show the
+diff chunk with that index.
 
 =item emacs
 
@@ -1141,7 +1141,7 @@ Defines the character used to indicate omitted text in large unchanged text
 when C<--ellipsis>/C<-e> is in effect.
 
 This character is not equally well visible on all terminals or in all fonts,
-so you might want to chane it to something that stands out better in you
+so you might want to change it to something that stands out better in your
 environment. Possible suggestions:
 
  … U+2026 HORIZONTAL ELLIPSIS
@@ -1170,7 +1170,7 @@ environment. Possible suggestions:
 
  chr_eli_v : U+21A4U+21A6
 
-When ussing C<--ellipsis> with C<--verbose> level 2 or up, the single character
+When using C<--ellipsis> with C<--verbose> level 2 or up, the single character
 indicator will be replaced with this character. If it is 2 characters wide, the
 length of the compressed part is put between the characters.
 
@@ -1207,7 +1207,7 @@ kept in memory, this tool might not be able to deal with (very) large datasets.
 
 =head2 Speed
 
-There are situations where L<Algorithm::Diff> takes considerable more time
+There are situations where L<Algorithm::Diff> takes considerably more time
 compared to e.g. GNU diff. Installing L<Algorithm::Diff::XS> will make
 C<ccdiff> a lot faster. C<ccdiff> will choose L<Algorithm::Diff::XS> if
 available.

--- a/doc/ccdiff.3
+++ b/doc/ccdiff.3
@@ -157,7 +157,7 @@ ccdiff \- Colored Character diff
 .IX Subsection "Command line options"
 .IP "\-\-help \-?" 2
 .IX Item "--help -?"
-Show a summary op the available command-line options and exit.
+Show a summary of the available command-line options and exit.
 .IP "\-\-version \-V" 2
 .IX Item "--version -V"
 Show the version and exit.
@@ -285,7 +285,7 @@ as \f(CW\*(C`chr_old\*(C'\fR (the character used as marker under removed charact
 \&\f(CW\*(C`chr_new\*(C'\fR (the character used as marker under added characters).
 .Sp
 If \f(CW\*(C`\-\-ellipsis\*(C'\fR is also in effect and either the \f(CW\*(C`chr_eli\*(C'\fR is longer than
-one character or \f(CW\*(C`\-\-verbose\*(C'\fR level is over 2, this options is automatically
+one character or \f(CW\*(C`\-\-verbose\*(C'\fR level is over 2, this option is automatically
 disabled.
 .IP "\-\-ascii \-a" 2
 .IX Item "--ascii -a"
@@ -359,7 +359,7 @@ Defines the number of lines a change block may differ before the fall-back of
 horizontal diff to vertical diff.
 .Sp
 If a chunk describes a change, and the number of lines in the original block
-has less or more lines than the new block and that difference exceeds this
+has fewer or more lines than the new block and that difference exceeds this
 threshold, \f(CW\*(C`ccdiff\*(C'\fR will fall-back to vertical diff.
 .IP "\-\-heuristics=n \-h n" 2
 .IX Item "--heuristics=n -h n"
@@ -409,11 +409,11 @@ Ignore all white-space changes. This will set all options \f(CW\*(C`\-b\*(C'\fR,
 and \f(CW\*(C`\-B\*(C'\fR.
 .IP "\-\-ignore\-trailing\-space \-Z" 2
 .IX Item "--ignore-trailing-space -Z"
-Ignore changes in trailing white-space (\s-1TAB\s0's and spaces).
+Ignore changes in trailing white-space (tabs and spaces).
 .IP "\-\-ignore\-ws|ignore\-space\-change \-b" 2
 .IX Item "--ignore-ws|ignore-space-change -b"
-Ignore changes in horizontal white-space (\s-1TAB\s0's and spaces). This does not
-include white-space changes that splits non-white-space or removes white-space
+Ignore changes in horizontal white-space (tabs and spaces). This does not
+include white-space changes that split non-white-space or remove white-space
 between two non-white-space elements.
 .IP "\-\-ignore\-tab\-expansion \-E" 2
 .IX Item "--ignore-tab-expansion -E"
@@ -436,10 +436,10 @@ in this order:
 and evaluated in that order. Any options specified in a file later in that
 chain will overwrite previously set options.
 .PP
-Option files are only read and evaluated if it is not empty and not writable
+Option files are only read and evaluated if they are not empty and not writable
 by others than the owner.
 .PP
-The syntax of the file is one option per line. where leading and trailing
+The syntax of the file is one option per line, where leading and trailing
 white-space is ignored. If that line then starts with one of the options
 listed below, followed by optional white-space followed by either an \f(CW\*(C`=\*(C'\fR or
 a \f(CW\*(C`:\*(C'\fR, followed by optional white-space and the values, the value is assigned
@@ -488,7 +488,7 @@ default background color.
 .IP "swap (\-s)" 2
 .IX Item "swap (-s)"
 .Vb 1
-\& reverse : false
+\& swap    : false
 .Ve
 .Sp
 Swap the colors for new and old.
@@ -520,7 +520,7 @@ This option may also be specified as
 \& old     : red
 .Ve
 .Sp
-Defines the color to be used for delete text. The default is \f(CW\*(C`red\*(C'\fR.
+Defines the color to be used for deleted text. The default is \f(CW\*(C`red\*(C'\fR.
 .Sp
 The color \f(CW\*(C`none\*(C'\fR is also accepted and disables this color.
 .Sp
@@ -573,7 +573,7 @@ This option may also be specified as
 Defines if a header is displayed above the diff (default is 1), supported
 colors are allowed.
 .Sp
-If the values is a valid supported color, it will show the header in that
+If the value is a valid supported color, it will show the header in that
 color scheme.  To disable the header set it to \f(CW0\fR in the \s-1RC\s0 file or use
 \&\f(CW\*(C`\-\-no\-header\*(C'\fR as a command line argument.
 .IP "verbose" 2
@@ -638,8 +638,8 @@ with this option, it would be
 \& [005] 42a42,42
 .Ve
 .Sp
-When this option contains a positive integer, \f(CW\*(C`ccdiff\*(C'\fR will only show diff
-the diff chunk with that index.
+When this option contains a positive integer, \f(CW\*(C`ccdiff\*(C'\fR will only show the
+diff chunk with that index.
 .IP "emacs" 2
 .IX Item "emacs"
 .Vb 1
@@ -721,7 +721,7 @@ Defines the character used to indicate omitted text in large unchanged text
 when \f(CW\*(C`\-\-ellipsis\*(C'\fR/\f(CW\*(C`\-e\*(C'\fR is in effect.
 .Sp
 This character is not equally well visible on all terminals or in all fonts,
-so you might want to chane it to something that stands out better in you
+so you might want to change it to something that stands out better in your
 environment. Possible suggestions:
 .Sp
 .Vb 10
@@ -753,7 +753,7 @@ environment. Possible suggestions:
 \& chr_eli_v : U+21A4U+21A6
 .Ve
 .Sp
-When ussing \f(CW\*(C`\-\-ellipsis\*(C'\fR with \f(CW\*(C`\-\-verbose\*(C'\fR level 2 or up, the single character
+When using \f(CW\*(C`\-\-ellipsis\*(C'\fR with \f(CW\*(C`\-\-verbose\*(C'\fR level 2 or up, the single character
 indicator will be replaced with this character. If it is 2 characters wide, the
 length of the compressed part is put between the characters.
 .Sp
@@ -789,7 +789,7 @@ Due to the implementation, where both sides of the comparison are completely
 kept in memory, this tool might not be able to deal with (very) large datasets.
 .SS "Speed"
 .IX Subsection "Speed"
-There are situations where Algorithm::Diff takes considerable more time
+There are situations where Algorithm::Diff takes considerably more time
 compared to e.g. \s-1GNU\s0 diff. Installing Algorithm::Diff::XS will make
 \&\f(CW\*(C`ccdiff\*(C'\fR a lot faster. \f(CW\*(C`ccdiff\*(C'\fR will choose Algorithm::Diff::XS if
 available.

--- a/doc/ccdiff.html
+++ b/doc/ccdiff.html
@@ -55,7 +55,7 @@ ccdiff --info</code></pre>
 <dt id="help">--help -?</dt>
 <dd>
 
-<p>Show a summary op the available command-line options and exit.</p>
+<p>Show a summary of the available command-line options and exit.</p>
 
 </dd>
 <dt id="version--V">--version -V</dt>
@@ -172,7 +172,7 @@ ccdiff --info</code></pre>
 
 <p>The characters used for the markers can be defined in your configuration file as <code>chr_old</code> (the character used as marker under removed characters) and <code>chr_new</code> (the character used as marker under added characters).</p>
 
-<p>If <code>--ellipsis</code> is also in effect and either the <code>chr_eli</code> is longer than one character or <code>--verbose</code> level is over 2, this options is automatically disabled.</p>
+<p>If <code>--ellipsis</code> is also in effect and either the <code>chr_eli</code> is longer than one character or <code>--verbose</code> level is over 2, this option is automatically disabled.</p>
 
 </dd>
 <dt id="ascii--a">--ascii -a</dt>
@@ -262,7 +262,7 @@ ccdiff --info</code></pre>
 
 <p>Defines the number of lines a change block may differ before the fall-back of horizontal diff to vertical diff.</p>
 
-<p>If a chunk describes a change, and the number of lines in the original block has less or more lines than the new block and that difference exceeds this threshold, <code>ccdiff</code> will fall-back to vertical diff.</p>
+<p>If a chunk describes a change, and the number of lines in the original block has fewer or more lines than the new block and that difference exceeds this threshold, <code>ccdiff</code> will fall-back to vertical diff.</p>
 
 </dd>
 <dt id="heuristics-n--h-n">--heuristics=n -h n</dt>
@@ -320,7 +320,7 @@ ccdiff --info</code></pre>
 <dt id="ignore-ws-ignore-space-change--b">--ignore-ws|ignore-space-change -b</dt>
 <dd>
 
-<p>Ignore changes in horizontal white-space (TAB&#39;s and spaces). This does not include white-space changes that splits non-white-space or removes white-space between two non-white-space elements.</p>
+<p>Ignore changes in horizontal white-space (TAB&#39;s and spaces). This does not include white-space changes that split non-white-space or remove white-space between two non-white-space elements.</p>
 
 </dd>
 <dt id="ignore-tab-expansion--E">--ignore-tab-expansion -E</dt>
@@ -347,9 +347,9 @@ ccdiff --info</code></pre>
 
 <p>and evaluated in that order. Any options specified in a file later in that chain will overwrite previously set options.</p>
 
-<p>Option files are only read and evaluated if it is not empty and not writable by others than the owner.</p>
+<p>Option files are only read and evaluated if they are not empty and not writable by others than the owner.</p>
 
-<p>The syntax of the file is one option per line. where leading and trailing white-space is ignored. If that line then starts with one of the options listed below, followed by optional white-space followed by either an <code>=</code> or a <code>:</code>, followed by optional white-space and the values, the value is assigned to the option. The values <code>no</code> and <code>false</code> (case insensitive) are aliases for <code>0</code>. The values <code>yes</code> and <code>true</code> are aliases to <code>-1</code> (<code>-1</code> being a true value).</p>
+<p>The syntax of the file is one option per line, where leading and trailing white-space is ignored. If that line then starts with one of the options listed below, followed by optional white-space followed by either an <code>=</code> or a <code>:</code>, followed by optional white-space and the values, the value is assigned to the option. The values <code>no</code> and <code>false</code> (case insensitive) are aliases for <code>0</code>. The values <code>yes</code> and <code>true</code> are aliases to <code>-1</code> (<code>-1</code> being a true value).</p>
 
 <p>Between parens is the corresponding command-line option.</p>
 
@@ -392,7 +392,7 @@ ccdiff --info</code></pre>
 <dt id="swap--s1">swap (-s)</dt>
 <dd>
 
-<pre><code>reverse : false</code></pre>
+<pre><code>swap    : false</code></pre>
 
 <p>Swap the colors for new and old.</p>
 
@@ -421,7 +421,7 @@ new_colour</code></pre>
 
 <pre><code>old     : red</code></pre>
 
-<p>Defines the color to be used for delete text. The default is <code>red</code>.</p>
+<p>Defines the color to be used for deleted text. The default is <code>red</code>.</p>
 
 <p>The color <code>none</code> is also accepted and disables this color.</p>
 
@@ -467,7 +467,7 @@ header  : blue_on_white</code></pre>
 
 <p>Defines if a header is displayed above the diff (default is 1), supported colors are allowed.</p>
 
-<p>If the values is a valid supported color, it will show the header in that color scheme. To disable the header set it to <code>0</code> in the RC file or use <code>--no-header</code> as a command line argument.</p>
+<p>If the value is a valid supported color, it will show the header in that color scheme. To disable the header set it to <code>0</code> in the RC file or use <code>--no-header</code> as a command line argument.</p>
 
 </dd>
 <dt id="verbose">verbose</dt>
@@ -522,7 +522,7 @@ utf-8</code></pre>
 [002] 19,19d18
 [005] 42a42,42</code></pre>
 
-<p>When this option contains a positive integer, <code>ccdiff</code> will only show diff the diff chunk with that index.</p>
+<p>When this option contains a positive integer, <code>ccdiff</code> will only show the diff chunk with that index.</p>
 
 </dd>
 <dt id="emacs">emacs</dt>
@@ -600,7 +600,7 @@ utf-8</code></pre>
 
 <p>Defines the character used to indicate omitted text in large unchanged text when <code>--ellipsis</code>/<code>-e</code> is in effect.</p>
 
-<p>This character is not equally well visible on all terminals or in all fonts, so you might want to chane it to something that stands out better in you environment. Possible suggestions:</p>
+<p>This character is not equally well visible on all terminals or in all fonts, so you might want to change it to something that stands out better in your environment. Possible suggestions:</p>
 
 <pre><code>&hellip; U+2026 HORIZONTAL ELLIPSIS
 &#x2034; U+2034 TRIPLE PRIME
@@ -630,7 +630,7 @@ utf-8</code></pre>
 
 <pre><code>chr_eli_v : U+21A4U+21A6</code></pre>
 
-<p>When ussing <code>--ellipsis</code> with <code>--verbose</code> level 2 or up, the single character indicator will be replaced with this character. If it is 2 characters wide, the length of the compressed part is put between the characters.</p>
+<p>When using <code>--ellipsis</code> with <code>--verbose</code> level 2 or up, the single character indicator will be replaced with this character. If it is 2 characters wide, the length of the compressed part is put between the characters.</p>
 
 <p>A suggested alternative might be U+21E4U+21E5</p>
 
@@ -664,7 +664,7 @@ $ git ccdiff 5c5a39f2</code></pre>
 
 <h2 id="Speed">Speed</h2>
 
-<p>There are situations where <a>Algorithm::Diff</a> takes considerable more time compared to e.g. GNU diff. Installing <a>Algorithm::Diff::XS</a> will make <code>ccdiff</code> a lot faster. <code>ccdiff</code> will choose <a>Algorithm::Diff::XS</a> if available.</p>
+<p>There are situations where <a>Algorithm::Diff</a> takes considerably more time compared to e.g. GNU diff. Installing <a>Algorithm::Diff::XS</a> will make <code>ccdiff</code> a lot faster. <code>ccdiff</code> will choose <a>Algorithm::Diff::XS</a> if available.</p>
 
 <h1 id="SEE-ALSO">SEE ALSO</h1>
 

--- a/doc/ccdiff.man
+++ b/doc/ccdiff.man
@@ -16,7 +16,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
 [1mOPTIONS[0m
    [1mCommand line options[0m
        --help -?
-         Show a summary op the available command-line options and exit.
+         Show a summary of the available command-line options and exit.
 
        --version -V
          Show the version and exit.
@@ -135,7 +135,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
          added characters).
 
          If "--ellipsis" is also in effect and either the "chr_eli" is longer
-         than one character or "--verbose" level is over 2, this options is
+         than one character or "--verbose" level is over 2, this option is
          automatically disabled.
 
        --ascii -a
@@ -207,7 +207,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
          fall-back of horizontal diff to vertical diff.
 
          If a chunk describes a change, and the number of lines in the
-         original block has less or more lines than the new block and that
+         original block has fewer or more lines than the new block and that
          difference exceeds this threshold, "ccdiff" will fall-back to
          vertical diff.
 
@@ -255,12 +255,12 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
          "-E", and "-B".
 
        --ignore-trailing-space -Z
-         Ignore changes in trailing white-space (TAB's and spaces).
+         Ignore changes in trailing white-space (tabs and spaces).
 
        --ignore-ws|ignore-space-change -b
-         Ignore changes in horizontal white-space (TAB's and spaces). This
-         does not include white-space changes that splits non-white-space or
-         removes white-space between two non-white-space elements.
+         Ignore changes in horizontal white-space (tabs and spaces). This
+         does not include white-space changes that split non-white-space or
+         remove white-space between two non-white-space elements.
 
        --ignore-tab-expansion -E
          NYI
@@ -280,10 +280,10 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
        and evaluated in that order. Any options specified in a file later in
        that chain will overwrite previously set options.
 
-       Option files are only read and evaluated if it is not empty and not
+       Option files are only read and evaluated if they are not empty and not
        writable by others than the owner.
 
-       The syntax of the file is one option per line. where leading and
+       The syntax of the file is one option per line, where leading and
        trailing white-space is ignored. If that line then starts with one of
        the options listed below, followed by optional white-space followed by
        either an "=" or a ":", followed by optional white-space and the
@@ -323,7 +323,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
          ("new" or "old") over the default background color.
 
        swap (-s)
-          reverse : false
+          swap    : false
 
          Swap the colors for new and old.
 
@@ -348,7 +348,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
        old (--old)
           old     : red
 
-         Defines the color to be used for delete text. The default is "red".
+         Defines the color to be used for deleted text. The default is "red".
 
          The color "none" is also accepted and disables this color.
 
@@ -393,7 +393,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
          Defines if a header is displayed above the diff (default is 1),
          supported colors are allowed.
 
-         If the values is a valid supported color, it will show the header in
+         If the value is a valid supported color, it will show the header in
          that color scheme.  To disable the header set it to 0 in the RC file
          or use "--no-header" as a command line argument.
 
@@ -446,7 +446,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
           [005] 42a42,42
 
          When this option contains a positive integer, "ccdiff" will only show
-         diff the diff chunk with that index.
+         the diff chunk with that index.
 
        emacs
           emacs   : no
@@ -510,8 +510,8 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
          unchanged text when "--ellipsis"/"-e" is in effect.
 
          This character is not equally well visible on all terminals or in all
-         fonts, so you might want to chane it to something that stands out
-         better in you environment. Possible suggestions:
+         fonts, so you might want to change it to something that stands out
+         better in your environment. Possible suggestions:
 
           X U+2026 HORIZONTAL ELLIPSIS
           X U+2034 TRIPLE PRIME
@@ -538,7 +538,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
        chr_eli_v
           chr_eli_v : U+21A4U+21A6
 
-         When ussing "--ellipsis" with "--verbose" level 2 or up, the single
+         When using "--ellipsis" with "--verbose" level 2 or up, the single
          character indicator will be replaced with this character. If it is 2
          characters wide, the length of the compressed part is put between the
          characters.
@@ -572,7 +572,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
        (very) large datasets.
 
    [1mSpeed[0m
-       There are situations where Algorithm::Diff takes considerable more time
+       There are situations where Algorithm::Diff takes considerably more time
        compared to e.g. GNU diff. Installing Algorithm::Diff::XS will make
        "ccdiff" a lot faster. "ccdiff" will choose Algorithm::Diff::XS if
        available.

--- a/doc/ccdiff.md
+++ b/doc/ccdiff.md
@@ -18,7 +18,7 @@ ccdiff - Colored Character diff
 
 - --help -?
 
-    Show a summary op the available command-line options and exit.
+    Show a summary of the available command-line options and exit.
 
 - --version -V
 
@@ -137,7 +137,7 @@ ccdiff - Colored Character diff
     `chr_new` (the character used as marker under added characters).
 
     If `--ellipsis` is also in effect and either the `chr_eli` is longer than
-    one character or `--verbose` level is over 2, this options is automatically
+    one character or `--verbose` level is over 2, this option is automatically
     disabled.
 
 - --ascii -a
@@ -218,7 +218,7 @@ ccdiff - Colored Character diff
     horizontal diff to vertical diff.
 
     If a chunk describes a change, and the number of lines in the original block
-    has less or more lines than the new block and that difference exceeds this
+    has fewer or more lines than the new block and that difference exceeds this
     threshold, `ccdiff` will fall-back to vertical diff.
 
 - --heuristics=n -h n
@@ -269,12 +269,12 @@ ccdiff - Colored Character diff
 
 - --ignore-trailing-space -Z
 
-    Ignore changes in trailing white-space (TAB's and spaces).
+    Ignore changes in trailing white-space (tabs and spaces).
 
 - --ignore-ws|ignore-space-change -b
 
-    Ignore changes in horizontal white-space (TAB's and spaces). This does not
-    include white-space changes that splits non-white-space or removes white-space
+    Ignore changes in horizontal white-space (tabs and spaces). This does not
+    include white-space changes that split non-white-space or remove white-space
     between two non-white-space elements.
 
 - --ignore-tab-expansion -E
@@ -298,10 +298,10 @@ in this order:
 and evaluated in that order. Any options specified in a file later in that
 chain will overwrite previously set options.
 
-Option files are only read and evaluated if it is not empty and not writable
+Option files are only read and evaluated if they are not empty and not writable
 by others than the owner.
 
-The syntax of the file is one option per line. where leading and trailing
+The syntax of the file is one option per line, where leading and trailing
 white-space is ignored. If that line then starts with one of the options
 listed below, followed by optional white-space followed by either an `=` or
 a `:`, followed by optional white-space and the values, the value is assigned
@@ -346,7 +346,7 @@ Between parens is the corresponding command-line option.
 
 - swap (-s)
 
-        reverse : false
+        swap    : false
 
     Swap the colors for new and old.
 
@@ -373,7 +373,7 @@ Between parens is the corresponding command-line option.
 
         old     : red
 
-    Defines the color to be used for delete text. The default is `red`.
+    Defines the color to be used for deleted text. The default is `red`.
 
     The color `none` is also accepted and disables this color.
 
@@ -420,7 +420,7 @@ Between parens is the corresponding command-line option.
     Defines if a header is displayed above the diff (default is 1), supported
     colors are allowed.
 
-    If the values is a valid supported color, it will show the header in that
+    If the value is a valid supported color, it will show the header in that
     color scheme.  To disable the header set it to `0` in the RC file or use
     `--no-header` as a command line argument.
 
@@ -474,8 +474,8 @@ Between parens is the corresponding command-line option.
         [002] 19,19d18
         [005] 42a42,42
 
-    When this option contains a positive integer, `ccdiff` will only show diff
-    the diff chunk with that index.
+    When this option contains a positive integer, `ccdiff` will only show the
+    diff chunk with that index.
 
 - emacs
 
@@ -546,7 +546,7 @@ Between parens is the corresponding command-line option.
     when `--ellipsis`/`-e` is in effect.
 
     This character is not equally well visible on all terminals or in all fonts,
-    so you might want to chane it to something that stands out better in you
+    so you might want to change it to something that stands out better in your
     environment. Possible suggestions:
 
         … U+2026 HORIZONTAL ELLIPSIS
@@ -575,7 +575,7 @@ Between parens is the corresponding command-line option.
 
         chr_eli_v : U+21A4U+21A6
 
-    When ussing `--ellipsis` with `--verbose` level 2 or up, the single character
+    When using `--ellipsis` with `--verbose` level 2 or up, the single character
     indicator will be replaced with this character. If it is 2 characters wide, the
     length of the compressed part is put between the characters.
 
@@ -610,7 +610,7 @@ kept in memory, this tool might not be able to deal with (very) large datasets.
 
 ## Speed
 
-There are situations where [Algorithm::Diff](https://metacpan.org/pod/Algorithm%3A%3ADiff) takes considerable more time
+There are situations where [Algorithm::Diff](https://metacpan.org/pod/Algorithm%3A%3ADiff) takes considerably more time
 compared to e.g. GNU diff. Installing [Algorithm::Diff::XS](https://metacpan.org/pod/Algorithm%3A%3ADiff%3A%3AXS) will make
 `ccdiff` a lot faster. `ccdiff` will choose [Algorithm::Diff::XS](https://metacpan.org/pod/Algorithm%3A%3ADiff%3A%3AXS) if
 available.


### PR DESCRIPTION
This fixes a few typos I found in the documentation.

The source contains five copies of this documentation. Hopefully I succeeded in making all the same edits in each of the five copies.

I assume one of these copies is the master and that the others are generated from the master. In that case, it might be clearer for other contributors if the generated versions were removed from the repository.