### PR TITLE
Remove diff-so-fancy symlink to nonexistent file

### DIFF
--- a/Talk/diff-so-fancy
+++ b/Talk/diff-so-fancy
@@ -1,1 +1,0 @@
-diff-so-fancy-git/diff-so-fancy


### PR DESCRIPTION
This removes Talk/diff-so-fancy, which was a symlink to the nonexistent file diff-so-fancy-git/diff-so-fancy.

This broken symlink was added in 2b0e36292d91897af94f0df25eb5f2b5c60aa1fb along with a another broken symlink called klondiff. The klondiff symlink was already removed in c645433d07e914c3ee70f346f4b37d83a20c1d9c (though that's not mentioned in the commit message).