### PR TITLE
Fix git-ccdiff URL in git integration instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ $ git config --global diff.tool ccdiff
 $ git config --global difftool.prompt false
 $ git config --global difftool.ccdiff.cmd 'ccdiff --utf-8 -u -r $LOCAL $REMOTE'
 $ git difftool SHA~..SHA
-$ wget https://github.com/Tux/App-ccdiff/blob/master/Files/git-ccdiff \
+$ wget https://github.com/Tux/App-ccdiff/raw/master/Files/git-ccdiff \
     -O ~/bin/git-ccdiff
 $ perl -pi -e 's{/pro/bin/perl}{/usr/bin/env perl}' ~/bin/git-ccdiff
 $ chmod 755 ~/bin/git-ccdiff

--- a/ccdiff
+++ b/ccdiff
@@ -1186,7 +1186,7 @@ You can use ccdiff to show diffs in git. It may work like this:
  $ git config --global difftool.prompt false
  $ git config --global difftool.ccdiff.cmd 'ccdiff --utf-8 -u -r $LOCAL $REMOTE'
  $ git difftool SHA~..SHA
- $ wget https://github.com/Tux/App-ccdiff/blob/master/Files/git-ccdiff \
+ $ wget https://github.com/Tux/App-ccdiff/raw/master/Files/git-ccdiff \
     -O ~/bin/git-ccdiff
  $ perl -pi -e 's{/pro/bin/perl}{/usr/bin/env perl}' ~/bin/git-ccdiff
  $ chmod 755 ~/bin/git-ccdiff

--- a/doc/README.md
+++ b/doc/README.md
@@ -131,7 +131,7 @@ $ git config --global diff.tool ccdiff
 $ git config --global difftool.prompt false
 $ git config --global difftool.ccdiff.cmd 'ccdiff --utf-8 -u -r $LOCAL $REMOTE'
 $ git difftool SHA~..SHA
-$ wget https://github.com/Tux/App-ccdiff/blob/master/Files/git-ccdiff \
+$ wget https://github.com/Tux/App-ccdiff/raw/master/Files/git-ccdiff \
     -O ~/bin/git-ccdiff
 $ perl -pi -e 's{/pro/bin/perl}{/usr/bin/env perl}' ~/bin/git-ccdiff
 $ chmod 755 ~/bin/git-ccdiff

--- a/doc/ccdiff.html
+++ b/doc/ccdiff.html
@@ -645,7 +645,7 @@ utf-8</code></pre>
 $ git config --global difftool.prompt false
 $ git config --global difftool.ccdiff.cmd &#39;ccdiff --utf-8 -u -r $LOCAL $REMOTE&#39;
 $ git difftool SHA~..SHA
-$ wget https://github.com/Tux/App-ccdiff/blob/master/Files/git-ccdiff \
+$ wget https://github.com/Tux/App-ccdiff/raw/master/Files/git-ccdiff \
    -O ~/bin/git-ccdiff
 $ perl -pi -e &#39;s{/pro/bin/perl}{/usr/bin/env perl}&#39; ~/bin/git-ccdiff
 $ chmod 755 ~/bin/git-ccdiff

--- a/doc/ccdiff.man
+++ b/doc/ccdiff.man
@@ -552,7 +552,7 @@ STDIN(1)              User Contributed Perl Documentation             STDIN(1)
         $ git config --global difftool.prompt false
         $ git config --global difftool.ccdiff.cmd 'ccdiff --utf-8 -u -r $LOCAL $REMOTE'
         $ git difftool SHA~..SHA
-        $ wget https://github.com/Tux/App-ccdiff/blob/master/Files/git-ccdiff \
+        $ wget https://github.com/Tux/App-ccdiff/raw/master/Files/git-ccdiff \
            -O ~/bin/git-ccdiff
         $ perl -pi -e 's{/pro/bin/perl}{/usr/bin/env perl}' ~/bin/git-ccdiff
         $ chmod 755 ~/bin/git-ccdiff

--- a/doc/ccdiff.md
+++ b/doc/ccdiff.md
@@ -589,7 +589,7 @@ You can use ccdiff to show diffs in git. It may work like this:
     $ git config --global difftool.prompt false
     $ git config --global difftool.ccdiff.cmd 'ccdiff --utf-8 -u -r $LOCAL $REMOTE'
     $ git difftool SHA~..SHA
-    $ wget https://github.com/Tux/App-ccdiff/blob/master/Files/git-ccdiff \
+    $ wget https://github.com/Tux/App-ccdiff/raw/master/Files/git-ccdiff \
        -O ~/bin/git-ccdiff
     $ perl -pi -e 's{/pro/bin/perl}{/usr/bin/env perl}' ~/bin/git-ccdiff
     $ chmod 755 ~/bin/git-ccdiff


### PR DESCRIPTION
This PR fixes the git-ccdiff URL in git integration instructions. The old "blob" URL downloads an html page. The "raw" URL downloads the actual script.